### PR TITLE
Fix 'this.stops is not a function' error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ export default class Lottie extends React.Component {
     this.setAnimationControl();
 
     if (this.props.isStopped) {
-      this.stops();
+      this.stop();
     } else if (this.props.segments) {
       this.playSegments(true);
     } else {


### PR DESCRIPTION
![Captura de tela de 2020-06-18 20-56-33](https://user-images.githubusercontent.com/30233482/85083443-2749ee00-b1a8-11ea-8f45-c8650bbdeaf3.png)

It can be tested in the "toggle like" tab in the Storybook. :)

Caused by https://github.com/felippenardi/lottie-react-web/commit/a9a236acc484d042d0f26d35cabf1f0a27a4e639