### PR TITLE
Typecast speed to number in speed input

### DIFF
--- a/src/stories/lottie-control-segments.js
+++ b/src/stories/lottie-control-segments.js
@@ -44,7 +44,7 @@ export default class LottieControlSegment extends React.Component {
       <input
         style={centerStyle}
         type="range" value={speed} min="0" max="3" step="0.5"
-        onChange={e => this.setState({ speed: e.currentTarget.value })}
+        onChange={e => this.setState({ speed: +e.currentTarget.value })}
       />
       <p style={centerStyle}>Segment range: [{startFrame}, {endFrame}]</p>
       <div style={centerStyle}>

--- a/src/stories/lottie-control.js
+++ b/src/stories/lottie-control.js
@@ -41,7 +41,7 @@ export default class LottieControl extends React.Component {
       <input
         style={centerStyle}
         type="range" value={speed} min="0" max="3" step="0.5"
-        onChange={e => this.setState({ speed: e.currentTarget.value })}
+        onChange={e => this.setState({ speed: +e.currentTarget.value })}
       />
       <button
         style={centerStyle}


### PR DESCRIPTION
When changing the speed input value in the storybook, this warning was being displayed:
![Captura de tela de 2020-06-18 21-22-07](https://user-images.githubusercontent.com/30233482/85084705-fcfa2f80-b1ab-11ea-96de-43115a012ddd.png)

It can be tested in the "with controls" tab and in the "with segments" tab in the storybook. :)