### PR TITLE
Added TS typing for tabIndex

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,7 @@ declare module "lottie-react-web" {
     direction?: 1 | -1;
     ariaRole?: string;
     ariaLabel?: string;
+    tabIndex?: string | number;
     title?: string;
 
     // Not documented


### PR DESCRIPTION
Added missing typescript definition for new prop `tabIndex`, previously only defined in propTypes.