### PR TITLE
Change this.stops to this.stop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ export default class Lottie extends React.Component {
     this.setAnimationControl();
 
     if (this.props.isStopped) {
-      this.stops();
+      this.stop();
     } else if (this.props.segments) {
       this.playSegments(true);
     } else {


### PR DESCRIPTION
![Screen Shot 2020-12-11 at 4 11 01 PM](https://user-images.githubusercontent.com/14946478/101966035-81fa5a80-3bcb-11eb-9d4f-48a85f6e92ed.png)

I don't think `stops` is actually a valid function.

This meant that passing `isStopped` as a prop to the library would break immediately.